### PR TITLE
fix: handle temporal state vars in synchronize(); silence NaN cast wa…

### DIFF
--- a/dissmodel/geo/raster/sync_model.py
+++ b/dissmodel/geo/raster/sync_model.py
@@ -120,8 +120,16 @@ class SyncRasterModel(RasterModel):
 
         Does nothing if ``land_use_types`` has not been set yet (safe to
         call before ``setup()`` completes).
+
+        If a state variable was loaded from a temporal catalog entry (shape
+        ``(time, y, x)``), the first slice is used as the initial state.
+        After the first step the model always writes back 2D arrays, so
+        subsequent snapshots are 2D unconditionally.
         """
         if not hasattr(self, "land_use_types"):
             return
         for name in self.land_use_types:
-            self.backend.set(name + "_past", self.backend.get(name).copy())
+            arr = self.backend.get(name)
+            if arr.ndim > 2:
+                arr = arr[0]
+            self.backend.set(name + "_past", arr.copy())

--- a/dissmodel/io/raster.py
+++ b/dissmodel/io/raster.py
@@ -209,6 +209,8 @@ def _write_geotiff(
                 name,
                 np.full((rows, cols), nodata, dtype=dtype),
             )
+            if np.issubdtype(np.dtype(dtype), np.integer):
+                arr = np.where(np.isfinite(arr), arr, nodata)
             arrays.append(arr.astype(dtype))
         names = [name for name, _, _ in band_spec]
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dissmodel"
-version = "0.6.1"
+version = "0.6.2"
 description = "Discrete Spatial Modeling framework for raster and vector simulations"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"


### PR DESCRIPTION
…rning

- sync_model.py: SyncRasterModel.synchronize() now takes arr[0] when a state variable is stored as (time, y, x) — happens when to_lucc_data() loads a variable that has temporal catalog entries. After the first step the model writes back 2D arrays so subsequent snapshots are 2D.
- io/raster.py: fill NaN/inf with the band nodata value before casting to integer dtype, eliminating the RuntimeWarning from float→int16 cast when raster arrays contain masked cells.